### PR TITLE
[f] TAC-54 - Tachio’s Missive API calls should use the personalized API token for each user’s requests (if available)

### DIFF
--- a/tachio/api.js
+++ b/tachio/api.js
@@ -108,7 +108,7 @@ function processWebhookPayload(payload) {
   return simplifiedPayload
 }
 
-async function processMissiveRequest(body) {
+async function processMissiveRequest(body, query) {
   // Require the processMessageChain function from the chain module
   const { processMessageChain } = await require('./src/chain')
 
@@ -287,12 +287,13 @@ async function processMissiveRequest(body) {
       })
     }
   }
+  const token = (query?.token?.length === 36) ? query.token : apiKey
   // POST the response back to the Missive API using the conversation ID
   const responsePost = await fetch(`${apiFront}/posts/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`
+      Authorization: `Bearer ${token}`
     },
     body: JSON.stringify({
       posts: {
@@ -342,7 +343,7 @@ app.post('/api/missive-reply', async (req, res) => {
 
   res.status(200).end()
 
-  processMissiveRequest(req.body)
+  processMissiveRequest(req.body, req.query)
     .then(() => {
       logger.info(`Message processed`)
     })


### PR DESCRIPTION
[TAC-54](https://linear.app/pdw/issue/TAC-54/tachios-missive-api-calls-should-use-the-personalized-api-token-for)