### PR TITLE
[c] Use gpt-4o for vision, add conversation_id and created_at to preambled messages

### DIFF
--- a/tachio/api.js
+++ b/tachio/api.js
@@ -126,7 +126,7 @@ async function processMissiveRequest(body, query) {
     .select('id')
     .in('missive_label_id', body.conversation.shared_labels)
     .limit(1)
-  let projectId = (data.length > 0) ? `Project ID: ${data[0].id}. \n` : ''
+  let projectId = (data?.length > 0) ? `Project ID: ${data[0].id}. \n` : ''
 
   const task = body.comment.task
   // Used for directing the LLM based on specific context:

--- a/tachio/api.js
+++ b/tachio/api.js
@@ -211,7 +211,7 @@ async function processMissiveRequest(body, query) {
   formattedMessages.push(
     ...contextMessages.map((m) => ({
         role: 'user',
-        content: `#### Contextual message in conversation:\n${m.value}`
+        content: `#### Contextual message in conversation ${m.conversation_id}:\n ${m.created_at} ${m.value}`
       })
     )
   )

--- a/tachio/capabilities/calendar.js
+++ b/tachio/capabilities/calendar.js
@@ -196,7 +196,7 @@ function extractCalendarData(event) {
 module.exports = {
   handleCapabilityMethod: async (method, args) => {
     const jsonArgs = parseJSONArg(args)
-    logger.info(`⚡️ Calling capability method: calendar.${method} \n ${jsonArgs}`);
+    logger.info(`⚡️ Calling capability method: calendar.${method} \n ${JSON.stringify(jsonArgs)}`);
 
     switch (method) {
       case "listAllCalendars":

--- a/tachio/helpers.js
+++ b/tachio/helpers.js
@@ -876,7 +876,7 @@ async function addUserMessages(username, messages) {
     userMessages.forEach((message) => {
       messages.push({
         role: "user",
-        content: `${message.value}`,
+        content: `${message.created_at}, in conversation ${message.conversation_id}: ${message.value}`,
       });
     });
   } catch (error) {
@@ -898,7 +898,7 @@ async function addUserMemories(username, messages) {
     userMemories.forEach((memory) => {
       messages.push({
         role: "system",
-        content: `You remember from a previous interaction on ${memory.created_at}: ${memory.value}`,
+        content: `You remember from a previous interaction on ${memory.created_at}, in conversation: ${memory.conversation_id}: ${memory.value}`,
       });
     });
   } catch (err) {
@@ -945,7 +945,7 @@ async function addRelevantMemories(username, messages) {
       logger.info('relevant memory ' + JSON.stringify(memory))
       messages.push({
         role: 'system',
-        content: `${memory.created_at}: ${memory.value}`
+        content: `${memory.created_at}, in conversation: ${memory.conversation_id}: ${memory.value}`
       })
     })
   } catch (err) {
@@ -966,7 +966,7 @@ async function addGeneralMemories(messages) {
     generalMemories.forEach((memory) => {
       messages.push({
         role: "system",
-        content: `${memory.created_at}: ${memory.value}`,
+        content: `${memory.created_at} in conversation: ${memory.conversation_id}: ${memory.value}`,
       });
     });
   } catch (err) {

--- a/tachio/helpers.js
+++ b/tachio/helpers.js
@@ -1450,5 +1450,6 @@ module.exports = {
   toolUseCapabilityRegex,
   anthropicThinkingRegex,
   notificationRegex,
+  lastUserMessage,
   TODO_TABLE_NAME
 };

--- a/tachio/src/missive.js
+++ b/tachio/src/missive.js
@@ -497,7 +497,10 @@ async function processDailyReport(payload) {
 async function sendMissiveResponse(lastMessage, requestQuery, conversationId) {
   // Separate thinking part out of result part of Claude's message
   const messageMatches = lastMessage.content.match(anthropicThinkingRegex)
-  let notification
+  let notification = {
+    title: BOT_NAME,
+    body: ''
+  }
   const attachments = []
   if (messageMatches && messageMatches.length > 2) {
     // Thinking part is always presented
@@ -513,10 +516,6 @@ async function sendMissiveResponse(lastMessage, requestQuery, conversationId) {
         notification = JSON.parse(notificationMatches[1])
       } catch (error) {
         logger.error('Error parsing notification:', error, notificationMatches[1])
-        notification = {
-          title: BOT_NAME,
-          body: ''
-        }
       }
     }
     // Add result part

--- a/tachio/src/missive.js
+++ b/tachio/src/missive.js
@@ -551,7 +551,7 @@ async function sendMissiveResponse(lastMessage, requestQuery, conversationId) {
 
   // Log the response status and body from the Missive API
   logger.info(`Response post status: ${responsePost.status}`)
-  logger.info(`Response post body: ${JSON.stringify(responsePost)}`)
+  logger.info(`Response post body: ${JSON.stringify(await responsePost.json())}`)
 }
 
 module.exports = {

--- a/tachio/src/vision.js
+++ b/tachio/src/vision.js
@@ -11,7 +11,7 @@ const fetchImageDescription = async () => {
   logger.info(`Requesting description of image at ${imageUrl}`);
   try {
     const completion = await openai.chat.completions.create({
-      model: "gpt-4-vision-preview",
+      model: "gpt-4o",
       max_tokens: 1024,
       messages: [
         {


### PR DESCRIPTION
[TAC-136](https://linear.app/pdw/issue/TAC-136/for-handling-images-replace-gpt4vision-with-gpt4o)
[TAC-137](https://linear.app/pdw/issue/TAC-137/preambled-user-messages-and-user-memories-should-include-the)