### PR TITLE
TAC-95 - The memories table should store the Missive conversation ID in the conversation_id column

### DIFF
--- a/tachio/src/memory.js
+++ b/tachio/src/memory.js
@@ -90,7 +90,7 @@ module.exports = (async () => {
     if (rememberText && rememberText !== "✨" && rememberText.length > 0) {
       logger.info(`Storing user memory for ${username}`);
       await storeUserMemory(
-        { username, channel, conversation_id: channel, related_message_id },
+        { username, channel, conversationId: channel, relatedMessageId: related_message_id },
         rememberText
       );
     }


### PR DESCRIPTION
[TAC-95](https://linear.app/pdw/issue/TAC-95/the-memories-table-should-store-the-missive-conversation-id-in-the)